### PR TITLE
geo didn't feature use-serde preventing gladius_shared from being built

### DIFF
--- a/gladius_shared/Cargo.toml
+++ b/gladius_shared/Cargo.toml
@@ -11,7 +11,7 @@ zip = "0.5.13"
 nom_stl = "0.2.2"
 serde = { version = "1.0", features = ["derive"] }
 serde-xml-rs = "0.5.1"
-geo = "0.18.0"
+geo = {version = "0.18.0", features = ["use-serde"]}
 nalgebra = "0.27.1"
 deser-hjson = "1.0.2"
 serde_json = "1.0.74"


### PR DESCRIPTION
for GladiusSlicer's Cargo.toml (and thus the version of geo used to build it) geo has use-serde feature enabled however gladius-shared did not preventing gladius_shared from being built independently. 